### PR TITLE
Polish the CRAN release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ jobs:
   include:
   - r: release
   - r: devel
+  - r: oldrel
 
 # If one fails, avoid running the other.
 matrix:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,4 +30,3 @@ Suggests:
 RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
-Remotes: tmsalab/simcdm

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,8 @@ Package: dina
 Type: Package
 Title: Bayesian Estimation of DINA Model
 Version: 2.0.0
-Authors@R: c(person("Steven Andrew", "Culpepper", 
+Authors@R: c(
+             person("Steven Andrew", "Culpepper", 
                     email = "sculpepp@illinois.edu",
                     role = c("aut", "cph"),
                     comment = c(ORCID = "0000-0003-4226-6176")
@@ -10,7 +11,8 @@ Authors@R: c(person("Steven Andrew", "Culpepper",
              person("James Joseph", "Balamuta", 
                     email = "balamut2@illinois.edu",
                     role = c("aut", "cre"),
-                    comment = c(ORCID = "0000-0003-2826-8458"))
+                    comment = c(ORCID = "0000-0003-2826-8458")
+                    )
             )
 Description: Estimate the Deterministic Input, Noisy "And" Gate (DINA)
     cognitive diagnostic model parameters using the Gibbs sampler described
@@ -18,7 +20,7 @@ Description: Estimate the Deterministic Input, Noisy "And" Gate (DINA)
 URL: https://github.com/tmsalab/dina
 BugReports: https://github.com/tmsalab/dina/issues
 License: GPL (>= 2)
-Depends: R (>= 3.5.0), simcdm
+Depends: R (>= 3.4.0), simcdm (>= 0.1.0)
 LinkingTo: Rcpp (>= 1.0.0), RcppArmadillo (>= 0.9.200), simcdm, rgen
 Imports: Rcpp (>= 1.0.0)
 Suggests: 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,7 +3,7 @@
 export(DINA_Gibbs)
 export(dina)
 importFrom(Rcpp,evalCpp)
-importFrom(simcdm,sim_attribute_classes)
+importFrom(simcdm,attribute_classes)
 importFrom(simcdm,sim_dina_items)
 importFrom(simcdm,sim_q_matrix)
 importFrom(simcdm,sim_subject_attributes)

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,19 @@
 
 - Switched internal portions of the package to use the `simcdm` _C++_ routines
   and imported _R_ level-routines.
-- Enabled markdown for inline documentiona with roxygen2.
 - Switched from `src/init.c` to autogeneration via Rcpp 0.12.15
 - Removed miscellaneous RNG seed. 
+
+## Documentation
+
+- Enabled markdown for inline documentiona with roxygen2.
+- Improved documentation flow
+
+## Deployment
+
+- Added TMSA Lab's Travis-CI configuration for testing across R versions.
+- Added Unit Tests for model reproducibility.
+- Added code coverage results.
 
 # dina 1.0.2
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -78,7 +78,7 @@ update_sg <- function(Y, Q, ALPHAS, ss_old, as0, bs0, ag0, bg0) {
 #' Steven Andrew Culpepper
 #'
 #' @seealso
-#' [simcdm::sim_dina_items()] and [simcdm::sim_attribute_classes()]
+#' [simcdm::sim_dina_items()] and [simcdm::attribute_classes()]
 #'
 #' @noRd
 DINA_Gibbs_cpp <- function(Y, Q, chain_length = 10000L) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,10 +9,10 @@
 #' @param Amat   A \eqn{C \times K}{C x K} `matrix` of latent classes.
 #' @param Q      A \eqn{N \times K}{N x K} `matrix` indicating which
 #'               skills are required for which items.
-#' @param ss     A \eqn{J} \code{vector} of item slipping parameters.
-#' @param gs     A \eqn{J} \code{vector} of item guessing parameters.
+#' @param ss     A \eqn{J} `vector` of item slipping parameters.
+#' @param gs     A \eqn{J} `vector` of item guessing parameters.
 #' @param Y      A \eqn{N \times J}{N x J} `matrix` of observed responses.
-#' @param PIs    A \eqn{C} \code{vector} of latent class probabilities.
+#' @param PIs    A \eqn{C} `vector` of latent class probabilities.
 #' @param ALPHAS A \eqn{N \times K}{N x K} `matrix` of latent attributes.
 #' @param delta0 A \eqn{J} `vector` of Dirichlet prior parameters.
 #'

--- a/R/dina-est.R
+++ b/R/dina-est.R
@@ -22,7 +22,7 @@
 #' Steven Andrew Culpepper and James Joseph Balamuta
 #' 
 #' @seealso 
-#' [simcdm::sim_dina_items()] and [simcdm::sim_attribute_classes()]
+#' [simcdm::sim_dina_items()] and [simcdm::attribute_classes()]
 #' 
 #' @export
 #' @examples

--- a/R/dina-package.R
+++ b/R/dina-package.R
@@ -1,5 +1,5 @@
 #' @useDynLib "dina", .registration=TRUE
 #' @importFrom Rcpp evalCpp
-#' @importFrom simcdm sim_dina_items sim_attribute_classes sim_q_matrix sim_subject_attributes
+#' @importFrom simcdm sim_dina_items attribute_classes sim_q_matrix sim_subject_attributes
 #' @aliases dina-package
 "_PACKAGE"

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,18 +1,25 @@
 ## Test environments
-* local OS X install, R 3.5.2
-* ubuntu 14.04 (on travis-ci), R 3.5.2
-* win-builder (devel and release)
+
+- local OS X install, R 3.5.2
+- ubuntu 14.04 (on travis-ci), R 3.5.2
+- win-builder (devel and release)
 
 ## R CMD check results
 
 0 errors | 0 warnings | 1 note
 
-We have one note related to spelling:
+Maintainer: 'James Joseph Balamuta <balamut2@illinois.edu>'
 
+New maintainer:
+  James Joseph Balamuta <balamut2@illinois.edu>
+Old maintainer(s):
+  Steven Andrew Culpepper <sculpepp@illinois.edu>
+  
 Possibly mis-spelled words in DESCRIPTION:
   Culpepper (10:8)
   
-The mis-spelled word is the author's last name. 
+- We are changing the maintainer of the package.
+- The mis-spelled word is a package author's last name. 
 
 ## Reverse dependencies
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,4 +1,4 @@
-citHeader("To cite the 'dina' package in publications use:")
+citHeader("To cite the 'dina' R package and methods paper in publications use:")
 
 citEntry(entry = "Manual",
          title        = "{dina: Bayesian Estimation of DINA Model}",
@@ -6,7 +6,7 @@ citEntry(entry = "Manual",
                                    as.person("James Joseph Balamuta")
                                   ),
          year         = 2019,
-         textVersion  = paste("Culpepper, S.A. and Balamuta, J.J. (2019)",
+         textVersion  = paste("Culpepper, S. A. and Balamuta, J. J. (2019)",
                               "dina: Bayesian Estimation of DINA Model.",
                               "URL https://cran.r-project.org/package=dina.")
 )

--- a/man/dina.Rd
+++ b/man/dina.Rd
@@ -166,7 +166,7 @@ print(PIoutput, digits = 3)
 }
 }
 \seealso{
-\code{\link[simcdm:sim_dina_items]{simcdm::sim_dina_items()}} and \code{\link[simcdm:sim_attribute_classes]{simcdm::sim_attribute_classes()}}
+\code{\link[simcdm:sim_dina_items]{simcdm::sim_dina_items()}} and \code{\link[simcdm:attribute_classes]{simcdm::attribute_classes()}}
 }
 \author{
 Steven Andrew Culpepper and James Joseph Balamuta

--- a/src/dina-estimation-routine.cpp
+++ b/src/dina-estimation-routine.cpp
@@ -186,7 +186,7 @@ Rcpp::List DINA_Gibbs_cpp(const arma::mat &Y, const arma::mat &Q,
     unsigned int K = Q.n_cols;
 
     // Number of Latent Classes (2^k)
-    unsigned int C = pow(2, K);
+    unsigned int C = static_cast<unsigned int>(pow(2.0, static_cast<double>(K)));
 
     // Generate the latent class alpha matrix
     arma::mat Amat = simcdm::sim_attribute_classes(K);

--- a/src/dina-estimation-routine.cpp
+++ b/src/dina-estimation-routine.cpp
@@ -168,7 +168,7 @@ Rcpp::List update_sg(const arma::mat &Y, const arma::mat &Q,
 //' Steven Andrew Culpepper
 //'
 //' @seealso
-//' [simcdm::sim_dina_items()] and [simcdm::sim_attribute_classes()]
+//' [simcdm::sim_dina_items()] and [simcdm::attribute_classes()]
 //'
 //' @noRd
 // [[Rcpp::export]]
@@ -189,7 +189,7 @@ Rcpp::List DINA_Gibbs_cpp(const arma::mat &Y, const arma::mat &Q,
     unsigned int C = static_cast<unsigned int>(pow(2.0, static_cast<double>(K)));
 
     // Generate the latent class alpha matrix
-    arma::mat Amat = simcdm::sim_attribute_classes(K);
+    arma::mat Amat = simcdm::attribute_classes(K);
 
     // Prior values for betas and Dirichlet distribution
     arma::vec delta0 = arma::ones<arma::vec>(C);

--- a/src/dina-estimation-routine.cpp
+++ b/src/dina-estimation-routine.cpp
@@ -10,10 +10,10 @@
 //' @param Amat   A \eqn{C \times K}{C x K} `matrix` of latent classes.
 //' @param Q      A \eqn{N \times K}{N x K} `matrix` indicating which
 //'               skills are required for which items.
-//' @param ss     A \eqn{J} \code{vector} of item slipping parameters.
-//' @param gs     A \eqn{J} \code{vector} of item guessing parameters.
+//' @param ss     A \eqn{J} `vector` of item slipping parameters.
+//' @param gs     A \eqn{J} `vector` of item guessing parameters.
 //' @param Y      A \eqn{N \times J}{N x J} `matrix` of observed responses.
-//' @param PIs    A \eqn{C} \code{vector} of latent class probabilities.
+//' @param PIs    A \eqn{C} `vector` of latent class probabilities.
 //' @param ALPHAS A \eqn{N \times K}{N x K} `matrix` of latent attributes.
 //' @param delta0 A \eqn{J} `vector` of Dirichlet prior parameters.
 //'


### PR DESCRIPTION
- Modifies _R_ dependency to R 3.4.0 (oldrel)
- Fix ambiguous `pow()` call.
- Rename `sim_attribute_classes()` to `attribute_classes()`.